### PR TITLE
Display correct amount of loot in share string

### DIFF
--- a/src/rogule/ui.cljs
+++ b/src/rogule/ui.cljs
@@ -162,7 +162,7 @@
   (let [c (count-entities inventory :name (name k))]
     (concat
       (for [x (range (k counts))]
-        (if (> x c)
+        (if (>= x c)
           (emoj-fn blank-sprite)
           (emoj-fn sprite)))
       (when (> c 0)


### PR DESCRIPTION
Fix for https://github.com/chr15m/rogule.com/issues/30